### PR TITLE
Dump timm graphs

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -24,7 +24,7 @@ from timm.models import create_model, is_model, list_models
 from timm.optim import create_optimizer_v2
 from timm.utils import setup_default_logging, set_jit_fuser
 
-from functorch._src.compilers import get_save_fx_default_func
+from functorch._src.compilers import graph_dumper_aot
 import torchdynamo
 from shutil import rmtree
 from torchdynamo.utils import clone_inputs
@@ -640,7 +640,7 @@ def _try_run(model_name, bench_fn, bench_kwargs, initial_batch_size, no_batch_si
                 with torchdynamo.optimize(aot_autograd_speedup_strategy):
                     results = bench.run()
             elif TIMM_BENCHMARK_DUMPGRAPH == 1:
-                save_fx_func = get_save_fx_default_func(model_name, folder_name, dump_example_input = False)
+                save_fx_func = graph_dumper_aot(model_name, folder_name, dump_example_input = False)
                 optimize_ctx = torchdynamo.optimize(
                     save_fx_func
                 )

--- a/benchmark.py
+++ b/benchmark.py
@@ -30,6 +30,7 @@ from shutil import rmtree
 from torchdynamo.utils import clone_inputs
 
 folder_name = "timm_graphs"
+TIMM_BENCHMARK_DUMPGRAPH=0
 torch.backends.cuda.matmul.allow_tf32 = True
 
 torch._C._jit_override_can_fuse_on_cpu(False)
@@ -638,7 +639,7 @@ def _try_run(model_name, bench_fn, bench_kwargs, initial_batch_size, no_batch_si
             if os.getenv('TIMM_BENCHMARK_ENABLE_TORCHDYNAMO') == '1':
                 with torchdynamo.optimize(aot_autograd_speedup_strategy):
                     results = bench.run()
-            elif os.getenv('TIMM_BENCHMARK_DUMPGRAPH') == '1':
+            elif TIMM_BENCHMARK_DUMPGRAPH == 1:
                 save_fx_func = get_save_fx_default_func(model_name, folder_name, dump_example_input = False)
                 optimize_ctx = torchdynamo.optimize(
                     save_fx_func
@@ -690,6 +691,8 @@ def benchmark(args):
     elif args.bench == 'dump':
         bench_fns = DumpBenchmarkRunner,
         prefixes = 'dump'
+        global TIMM_BENCHMARK_DUMPGRAPH
+        TIMM_BENCHMARK_DUMPGRAPH=1
     elif args.bench.startswith('profile'):
         # specific profiler used if included in bench mode string, otherwise default to deepspeed, fallback to fvcore
         if 'deepspeed' in args.bench:

--- a/gen_models.py
+++ b/gen_models.py
@@ -1,17 +1,8 @@
 import os
 import glob
-import argparse
-import collections
-import copy
-import csv
-import functools
-import gc
-import io
-import itertools
 import logging
 import os
 import subprocess
-import sys
 from shutil import rmtree
 import shlex
 
@@ -38,14 +29,36 @@ lm = list(models)
 lm.sort()
 # print(lm)
 
+batch_size_dict = {
+    "dpn107": 64,
+    "gluon_senet154": 64,
+    "gluon_xception65": 64,
+    "ig_resnext101_32x16d": 64,
+    "legacy_senet154": 64,
+    "nasnetalarge": 64,
+    "pnasnet5large": 64,
+    "resnetv2_101x1_bitm": 64,
+    "seresnet152d": 64,
+    "ssl_resnext101_32x16d": 64,
+
+}
+
+SKIP = {
+    "tresnet_l"
+}
 
 # with open('_models.txt', 'w') as f:
 #     for model in lm:
 #         f.write(model + '\n')
 for name in lm:
     current_name = name
+    if name in SKIP:
+        continue
     try:
-        cmd = shlex.split(f"python benchmark.py --fuser nvfuser --bench dump --model={name} -b 128")
+        batch_size = batch_size_dict.get(name, 128)
+        cmd = f"python benchmark.py --fuser nvfuser --bench dump --model={name} -b {batch_size}"
+        print(cmd)
+        cmd = shlex.split(cmd)
         subprocess.check_call(cmd)
         print(name, "success")
     except subprocess.SubprocessError:

--- a/gen_models.py
+++ b/gen_models.py
@@ -1,0 +1,55 @@
+import os
+import glob
+import argparse
+import collections
+import copy
+import csv
+import functools
+import gc
+import io
+import itertools
+import logging
+import os
+import subprocess
+import sys
+from shutil import rmtree
+import shlex
+
+models = set()
+folder_name = "timm_graphs"
+
+for fn in glob.glob('docs/models/*.md'):
+    with open(fn, 'r') as f:
+        while True:
+            line = f.readline()
+            if not line:
+                break
+
+            if not line.startswith('model = timm.create_model('):
+                continue
+
+            model = line.split("'")[1]
+
+            # print(model)
+            models.add(model)
+
+# print(models)
+lm = list(models)
+lm.sort()
+# print(lm)
+
+
+# with open('_models.txt', 'w') as f:
+#     for model in lm:
+#         f.write(model + '\n')
+for name in lm:
+    current_name = name
+    try:
+        cmd = shlex.split(f"python benchmark.py --fuser nvfuser --bench dump --model={name} -b 128")
+        subprocess.check_call(cmd)
+        print(name, "success")
+    except subprocess.SubprocessError:
+        print(name, "ERROR")
+        if os.path.exists(f"{folder_name}/{current_name}"):
+            rmtree(f"{folder_name}/{current_name}")
+        logging.exception("removing folder")


### PR DESCRIPTION
Scripts to dump TIMM graphs. Run `python gen_models.py` to dump TIMM graphs to folder `timm_graphs`.

Instruction to installation of repo: https://timm.fast.ai/



Comment out the following lines in functorch/_src/aot_autograd.py to avoid extra buffer registration

```
# @register_decomposition(aten.new_zeros, aot_autograd_decompositions)
# def new_zeros(inp, size, dtype=None, layout=None, device=None, pin_memory=None):
#     return torch.zeros(size, dtype=inp.dtype, device=inp.device)


# @register_decomposition(aten.new_full, aot_autograd_decompositions)
# def new_full(inp, size, value, dtype=None, layout=None, device=None, pin_memory=None):
#     return torch.full(size, value, dtype=inp.dtype, device=inp.device)
```

